### PR TITLE
This PR changes several things:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
-FROM fedora AS content-builder
+FROM centos:8 AS content-builder
 
-RUN dnf -y install cmake make git python3-pyyaml python3-jinja2 openscap-utils \
+ARG repo="https://github.com/ComplianceAsCode/content"
+ARG branch="master"
+
+RUN dnf -y install cmake make git /usr/bin/python3 python3-pyyaml python3-jinja2 openscap-utils \
     && rm -rf /var/cache/yum
-RUN  git clone https://github.com/jhrozek/content.git
+RUN  git clone $repo
 WORKDIR /content
 COPY build-ocp4-content.sh .
 RUN chmod u+x ./build-ocp4-content.sh && ./build-ocp4-content.sh
 
-FROM fedora
-WORKDIR /var/lib/content
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+WORKDIR /
 COPY --from=content-builder /content/build/ssg-ocp4-ds.xml .

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+APP_NAME=ocp4-openscap-content
+
+REPO?=quay.io/jhrozek
+CNT_RUNTIME?=podman
+
+CONTENT_REPO?=https://github.com/ComplianceAsCode/content
+CONTENT_BRANCH?=master
+
+.PHONY: build build-nocache tag-latest tag-branch push-latest push-branch
+
+all: build
+
+build:
+	$(CNT_RUNTIME) build --build-arg=repo=${CONTENT_REPO} --build-arg=branch=${CONTENT_BRANCH} -f Dockerfile -t $(APP_NAME)
+
+build-nocache:
+	$(CNT_RUNTIME) build --build-arg=repo=${CONTENT_REPO} --build-arg=branch=${CONTENT_BRANCH} --no-cache -f Dockerfile -t $(APP_NAME)
+
+tag-latest:
+	$(CNT_RUNTIME) tag $(APP_NAME) $(REPO)/$(APP_NAME):latest
+
+tag-branch:
+	$(CNT_RUNTIME) tag $(APP_NAME) $(REPO)/$(APP_NAME):$(shell git rev-parse --abbrev-ref HEAD)
+
+push-latest:
+	$(CNT_RUNTIME) push $(REPO)/$(APP_NAME):latest
+
+push-branch:
+	$(CNT_RUNTIME) push $(APP_NAME) $(REPO)/$(APP_NAME):$(shell git rev-parse --abbrev-ref HEAD)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# ocp4-openscap-content
+## ocp4-openscap-content
+
+This repository contains a Dockerfile and some associated scripts that
+build the OpenSCAP content for OCP4. It is not intended to be used on
+its own, but rather by the [compliance operator](https://github.com/jhrozek/compliance-operator).
+
+The point of having this container image building the content rather
+than using the RHEL RPM is two-fold:
+ * We can build the image with the content on a different schedule
+ * By having the container image with the content separate from the
+   scanner image, it gets easier to supply custom content for the scanner
+   just by providing a custom image.
+
+## Where does the content come from?
+By default, the Dockerfile fetches content from the master branch of the
+[upstream repository](https://github.com/ComplianceAsCode/content).
+If you want to build content from another repo or branch, just adjust the
+`repo` and `branch` arguments respectively during container build, e.g.
+by passing `--build-arg`.
+
+## Where is the content stored?
+Directly in `/`
+
+## Does the image need anything else than the content?
+The compliance operator uses `cp` to copy all XML files from the root, but
+that's it.

--- a/build-ocp4-content.sh
+++ b/build-ocp4-content.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-git checkout -b ocp4 --track origin/ocp4
+git checkout -b $branch --track origin/$branch
 pushd build
 cmake ..
 popd
-./build_product ocp4
+./build_product --debug ocp4
 pushd build
 ctest
 popd


### PR DESCRIPTION
- The resulting content container is based on RHEL-8 UBI minimal
  image
- The stage1 content-builder container is based on CentOS-8. This is
  not ideal, but some packages that we need in order to build the
  content from source are not provided with RHEL-8 UBI (unless
  running on a RHEL-8 machine using an active subscription). But
  it's still better than using Fedora in the sense that it's closer
  to RHEL-8. When we move the repo to openshift github org, we'll
  get access to all RHEL-8 repos automatically
- The repo and branch to build from can be passed during build time
  as arguments to podman build
- The content is stored at "/". This will make it easy for anyone
  who wants to use custom content to do that as they can just place
  content to root and be done with it.
- Because the OCP4 profile is not marked as production ready in its
  definition in the ComplicanceAsCode repo, we also need to build
  the content with --debug in order to process the incomplete
  profiles