### PR TITLE
Clone the repo into directory named "content"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG branch="master"
 
 RUN dnf -y install cmake make git /usr/bin/python3 python3-pyyaml python3-jinja2 openscap-utils \
     && rm -rf /var/cache/yum
-RUN  git clone $repo
+RUN  git clone $repo content
 WORKDIR /content
 COPY build-ocp4-content.sh .
 RUN chmod u+x ./build-ocp4-content.sh && ./build-ocp4-content.sh


### PR DESCRIPTION
When using parameters CONTENT_REPO and CONTENT_BRANCH, git clone command
will default to creating directory with same name as repo name.

This forces created directory to be 'content'.

Some folks may have it named differently, :)